### PR TITLE
Properly dispose stream & tcp client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ Desktop.ini
 $RECYCLE.BIN/
 
 eventLog.seed
+/.vs

--- a/FTPSClient/FTPSClient.cs
+++ b/FTPSClient/FTPSClient.cs
@@ -1685,6 +1685,7 @@ namespace AlexPilotti.FTPS.Client
         private void SwitchCtrlToClearMode()
         {
             ctrlSslStream.Close();
+            ctrlSslStream.Dispose();
             ctrlSslStream = null;
 
             SetupCtrlStreamReaderAndWriter(ctrlClient.GetStream());
@@ -1885,16 +1886,20 @@ namespace AlexPilotti.FTPS.Client
                 if (ctrlSslStream != null)
                 {
                     ctrlSslStream.Close();
+                    ctrlSslStream.Dispose();
                     ctrlSslStream = null;
                 }
 
                 ctrlSr.Close();
+                ctrlSr.Dispose();
                 ctrlSr = null;
 
                 ctrlSw.Close();
+                ctrlSw.Dispose();
                 ctrlSw = null;
 
                 ctrlClient.Close();
+                ctrlClient.Dispose();
                 ctrlClient = null;
 
                 waitingCompletionReply = false;
@@ -1908,10 +1913,12 @@ namespace AlexPilotti.FTPS.Client
                 if (dataSslStream != null)
                 {
                     dataSslStream.Close();
+                    dataSslStream.Dispose();
                     dataSslStream = null;
                 }
 
                 dataClient.Close();
+                dataClient.Dispose();
                 dataClient = null;
             }
 

--- a/FTPSClient/FTPSClient.csproj
+++ b/FTPSClient/FTPSClient.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AlexPilotti.FTPS.Client</RootNamespace>
     <AssemblyName>AlexPilotti.FTPS.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>FTPSClient.snk</AssemblyOriginatorKeyFile>

--- a/FTPSClientCmdApp/FTPSClientCmdApp.csproj
+++ b/FTPSClientCmdApp/FTPSClientCmdApp.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AlexPilotti.FTPS.Client.ConsoleApp</RootNamespace>
     <AssemblyName>ftps</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/FTPSClientCmdApp/app.config
+++ b/FTPSClientCmdApp/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
The missing dispose seems to leak SslStreams in memory (according to jetbrains dotMemory).